### PR TITLE
Add haskell benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.o
 *~
 /target/
+war-and-peace.txt

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Running the benchmarks:
 
 * Install the Rust toolchain
 * Run `cargo run --release`
+
+Running the haskell-based benchmarks
+
+* `curl http://www.gutenberg.org/files/2600/2600-0.txt -o war-and-peace.txt`
+* `./main.hs`

--- a/main.hs
+++ b/main.hs
@@ -1,0 +1,36 @@
+#!/usr/bin/env stack
+-- stack --resolver lts-12.12 script --package criterion --package process
+
+import Criterion
+import Criterion.Main
+import System.Process
+
+main = do
+  mapM_
+    (\((compiler, makeArgs), name) -> rawSystem compiler (makeArgs name))
+    impls
+  defaultMain
+    [ bench
+      name
+      (nfIO
+         (rawSystem
+            "sh"
+            ["-c", "cat war-and-peace.txt | exes/" ++ name ++ " > /dev/null"]))
+    | (_compiler, name) <- impls
+    ]
+  where
+    impls =
+      [ (gpp, "c-inplace")
+      , (ghc, "haskell-chrisdone")
+      , (rust, "rust-inplace")
+      , (rust, "rust-iterator")
+      , (ghc, "haskell-bytestring-simple")
+      , (ghc, "haskell-string")
+      ]
+    gpp =
+      ("g++", \name -> ["impls/" ++ name ++ ".c", "-O2", "-o", "exes/" ++ name])
+    rust =
+      ( "rustc"
+      , \name -> ["impls/" ++ name ++ ".rs", "-O", "-o", "exes/" ++ name])
+    ghc =
+      ("ghc", \name -> ["impls/" ++ name ++ ".hs", "-O2", "-o", "exes/" ++ name])


### PR DESCRIPTION
Results:

```
benchmarking c-inplace
time                 12.37 ms   (12.12 ms .. 12.68 ms)
                     0.996 R²   (0.993 R² .. 0.999 R²)
mean                 12.51 ms   (12.37 ms .. 12.69 ms)
std dev              411.7 μs   (314.9 μs .. 530.0 μs)
variance introduced by outliers: 10% (moderately inflated)

benchmarking haskell-chrisdone
time                 14.08 ms   (13.99 ms .. 14.17 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 14.22 ms   (14.15 ms .. 14.42 ms)
std dev              274.2 μs   (116.8 μs .. 505.0 μs)

benchmarking rust-inplace
time                 13.69 ms   (13.50 ms .. 13.91 ms)
                     0.996 R²   (0.989 R² .. 0.999 R²)
mean                 13.90 ms   (13.77 ms .. 14.16 ms)
std dev              481.8 μs   (308.1 μs .. 792.0 μs)
variance introduced by outliers: 11% (moderately inflated)

benchmarking rust-iterator
time                 44.20 ms   (43.89 ms .. 44.48 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 44.44 ms   (44.27 ms .. 44.77 ms)
std dev              441.9 μs   (219.5 μs .. 738.4 μs)

benchmarking haskell-bytestring-simple
time                 112.0 ms   (111.0 ms .. 113.3 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 111.1 ms   (110.4 ms .. 111.9 ms)
std dev              1.128 ms   (826.3 μs .. 1.574 ms)
variance introduced by outliers: 11% (moderately inflated)

benchmarking haskell-string
time                 253.5 ms   (242.5 ms .. 258.1 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 251.9 ms   (250.1 ms .. 253.6 ms)
std dev              2.284 ms   (1.398 ms .. 2.889 ms)
variance introduced by outliers: 16% (moderately inflated)
```